### PR TITLE
[#21] Header change optimizations

### DIFF
--- a/library/src/main/java/com/devbrackets/android/recyclerext/adapter/RecyclerHeaderAdapter.java
+++ b/library/src/main/java/com/devbrackets/android/recyclerext/adapter/RecyclerHeaderAdapter.java
@@ -102,14 +102,14 @@ public abstract class RecyclerHeaderAdapter<H extends ViewHolder, C extends View
     }
 
     /**
-     * Retrieves the view type for the specified position.
+     * Retrieves the view type for the specified adapterPosition.
      *
-     * @param position The position to determine the view type for
-     * @return The type of ViewHolder for the <code>position</code>
+     * @param adapterPosition The position to determine the view type for
+     * @return The type of ViewHolder for the <code>adapterPosition</code>
      */
     @Override
-    public int getItemViewType(int position) {
-        return core.getItemViewType(position);
+    public int getItemViewType(int adapterPosition) {
+        return core.getItemViewType(adapterPosition);
     }
 
     /**

--- a/library/src/main/java/com/devbrackets/android/recyclerext/adapter/RecyclerHeaderCursorAdapter.java
+++ b/library/src/main/java/com/devbrackets/android/recyclerext/adapter/RecyclerHeaderCursorAdapter.java
@@ -127,14 +127,14 @@ public abstract class RecyclerHeaderCursorAdapter<H extends ViewHolder, C extend
     }
 
     /**
-     * Retrieves the view type for the specified position.
+     * Retrieves the view type for the specified adapterPosition.
      *
-     * @param position The position to determine the view type for
-     * @return The type of ViewHolder for the <code>position</code>
+     * @param adapterPosition The position to determine the view type for
+     * @return The type of ViewHolder for the <code>adapterPosition</code>
      */
     @Override
-    public int getItemViewType(int position) {
-        return core.getItemViewType(position);
+    public int getItemViewType(int adapterPosition) {
+        return core.getItemViewType(adapterPosition);
     }
 
     /**

--- a/library/src/main/java/com/devbrackets/android/recyclerext/adapter/RecyclerHeaderListAdapter.java
+++ b/library/src/main/java/com/devbrackets/android/recyclerext/adapter/RecyclerHeaderListAdapter.java
@@ -105,12 +105,12 @@ public abstract class RecyclerHeaderListAdapter<H extends ViewHolder, C extends 
     /**
      * Retrieves the view type for the specified position.
      *
-     * @param position The position to determine the view type for
-     * @return The type of ViewHolder for the <code>position</code>
+     * @param adapterPosition The position to determine the view type for
+     * @return The type of ViewHolder for the <code>adapterPosition</code>
      */
     @Override
-    public int getItemViewType(int position) {
-        return core.getItemViewType(position);
+    public int getItemViewType(int adapterPosition) {
+        return core.getItemViewType(adapterPosition);
     }
 
     /**

--- a/library/src/main/java/com/devbrackets/android/recyclerext/adapter/header/HeaderAdapterDataObserver.java
+++ b/library/src/main/java/com/devbrackets/android/recyclerext/adapter/header/HeaderAdapterDataObserver.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2016 Brian Wernick
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.devbrackets.android.recyclerext.adapter.header;
+
+import android.support.annotation.NonNull;
+import android.support.v4.util.LongSparseArray;
+import android.support.v7.widget.RecyclerView;
+
+import java.util.List;
+
+/**
+ * Used to monitor data set changes to update the {@link HeaderCore#headerItems} so that we can correctly
+ * calculate the list item count and header indexes.
+ */
+public class HeaderAdapterDataObserver extends RecyclerView.AdapterDataObserver {
+    @NonNull
+    protected HeaderCore headerCore;    
+    @NonNull
+    protected HeaderApi headerApi;
+
+    public HeaderAdapterDataObserver(@NonNull HeaderCore headerCore, @NonNull HeaderApi headerApi) {
+        this.headerCore = headerCore;
+        this.headerApi = headerApi;
+    }
+
+    @Override
+    public void onChanged() {
+        calculateHeaderIndices();
+    }
+
+    @Override
+    public void onItemRangeChanged(int positionStart, int itemCount) {
+        // Only recalculates the headers if there was a change
+        for (int i = positionStart; i < positionStart + itemCount; i++) {
+            HeaderItem headerItem = headerCore.getHeaderForAdapterPosition(i);
+            long newHeaderId = headerApi.getHeaderId(headerApi.getChildPosition(i));
+
+            if (headerItem != null && headerItem.getId() != newHeaderId) {
+                calculateHeaderIndices();
+                break;
+            }
+        }
+    }
+
+    @Override
+    public void onItemRangeInserted(int positionStart, int itemCount) {
+        // Unlike the onItemRangeChanged insertions cause a few things that need to be handled
+        //     1. HeaderItem indexes below the insertion point need to be updated
+        //     2. If added to an existing header, the item count needs to be updated
+        //     3. If creating a new header, the HeaderItem(s) need to be created and inserted
+        // This is made more complex because insertions can occur at the start, middle, or end
+        // of an existing region (header children). Due to this we will just recalculate the
+        // headers on insertions for now
+
+        calculateHeaderIndices();
+    }
+
+    @Override
+    public void onItemRangeRemoved(int positionStart, int itemCount) {
+        // Unlike the onItemRangeChanged deletions cause a few things that need to be handled
+        //     1. HeaderItem indexes below the deletion point need to be updated
+        //     2. If removed from an existing header, the item count needs to be updated or the header removed
+        // This is made more complex because deletions can occur at the start, middle, or end
+        // of an existing region (header children). Due to this we will just recalculate the
+        // headers on deletions for now
+
+        calculateHeaderIndices();
+    }
+
+    @Override
+    public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
+        calculateHeaderIndices();
+    }
+
+    /**
+     * Performs a full calculation for the header indices
+     */
+    protected void calculateHeaderIndices() {
+        List<HeaderItem> items = headerCore.getHeaderItems();
+        LongSparseArray<Integer> counts = headerCore.getHeaderChildCountMap();
+        
+        items.clear();
+        counts.clear();
+        HeaderItem currentItem = null;
+
+        for (int i = 0; i < headerApi.getChildCount(); i++) {
+            long id = headerApi.getHeaderId(i);
+            if (id == RecyclerView.NO_ID) {
+                continue;
+            }
+
+            //Updates the child count for the headerId
+            Integer childCount = counts.get(id);
+            childCount = (childCount == null) ? 1 : childCount +1;
+            counts.put(id, childCount);
+
+            //Adds new headers to the list when detected
+            if (currentItem == null || currentItem.getId() != id) {
+                int position = i + (headerCore.showHeaderAsChild ? 0 : items.size());
+                currentItem = new HeaderItem(id, position);
+                items.add(currentItem);
+            }
+        }
+    }
+}

--- a/library/src/main/java/com/devbrackets/android/recyclerext/adapter/header/HeaderItem.java
+++ b/library/src/main/java/com/devbrackets/android/recyclerext/adapter/header/HeaderItem.java
@@ -22,19 +22,19 @@ package com.devbrackets.android.recyclerext.adapter.header;
  *  and {@link com.devbrackets.android.recyclerext.adapter.RecyclerHeaderCursorAdapter}
  */
 public class HeaderItem {
-    private long headerId;
-    private int viewPosition;
+    private long id;
+    private int adapterPosition;
 
-    public HeaderItem(long headerId, int viewPosition) {
-        this.headerId = headerId;
-        this.viewPosition = viewPosition;
+    public HeaderItem(long id, int adapterPosition) {
+        this.id = id;
+        this.adapterPosition = adapterPosition;
     }
 
-    public long getHeaderId() {
-        return headerId;
+    public long getId() {
+        return id;
     }
 
-    public int getViewPosition() {
-        return viewPosition;
+    public int getAdapterPosition() {
+        return adapterPosition;
     }
 }

--- a/library/src/main/java/com/devbrackets/android/recyclerext/adapter/helper/SimpleElevationItemTouchHelperCallback.java
+++ b/library/src/main/java/com/devbrackets/android/recyclerext/adapter/helper/SimpleElevationItemTouchHelperCallback.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 Brian Wernick
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.devbrackets.android.recyclerext.adapter.helper;
 
 import android.graphics.Canvas;

--- a/library/src/main/java/com/devbrackets/android/recyclerext/animation/FastScrollBubbleVisibilityAnimation.java
+++ b/library/src/main/java/com/devbrackets/android/recyclerext/animation/FastScrollBubbleVisibilityAnimation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 Brian Wernick
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.devbrackets.android.recyclerext.animation;
 
 import android.support.annotation.NonNull;

--- a/library/src/main/java/com/devbrackets/android/recyclerext/animation/FastScrollHandleVisibilityAnimation.java
+++ b/library/src/main/java/com/devbrackets/android/recyclerext/animation/FastScrollHandleVisibilityAnimation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 Brian Wernick
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.devbrackets.android.recyclerext.animation;
 
 import android.support.annotation.NonNull;

--- a/library/src/main/java/com/devbrackets/android/recyclerext/annotation/EdgeSpacing.java
+++ b/library/src/main/java/com/devbrackets/android/recyclerext/annotation/EdgeSpacing.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 Brian Wernick
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.devbrackets.android.recyclerext.annotation;
 
 import android.support.annotation.IntDef;

--- a/library/src/main/java/com/devbrackets/android/recyclerext/widget/FastScroll.java
+++ b/library/src/main/java/com/devbrackets/android/recyclerext/widget/FastScroll.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 Brian Wernick
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.devbrackets.android.recyclerext.widget;
 
 import android.annotation.TargetApi;

--- a/library/src/main/java/com/devbrackets/android/recyclerext/widget/PositionSupportImageView.java
+++ b/library/src/main/java/com/devbrackets/android/recyclerext/widget/PositionSupportImageView.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 Brian Wernick
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.devbrackets.android.recyclerext.widget;
 
 import android.annotation.TargetApi;

--- a/library/src/main/java/com/devbrackets/android/recyclerext/widget/PositionSupportTextView.java
+++ b/library/src/main/java/com/devbrackets/android/recyclerext/widget/PositionSupportTextView.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 Brian Wernick
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.devbrackets.android.recyclerext.widget;
 
 import android.annotation.TargetApi;


### PR DESCRIPTION
###### Fixes issue #21
- [x] This pull request follows the coding standards
###### This PR changes:
- Separated the Header data observer in to a separate class
- Optimized the calculation of header indices on item changes (not insertions or deletions)
- Added missing Copyright notices
- Updated `position` argument names to reflect if they are `childPosition` or `adapterPosition`
